### PR TITLE
added ignoreDirectories option to the configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,17 @@ autoDI:
         - %appDir%/../vendor
 ```
 
+You can ignore directories, like this: 
+```yaml
+autoDI:
+    directories:
+        - %appDir%
+        - %appDir%/../vendor
+    ignoreDirectories: 
+        - exludedDir
+        - anotherExludedDir
+```
+
 ## Register services on configuration
 
 Compiler extensions such as AutoDIExtension manipulates the DI container

--- a/src/AutoDI/DI/AutoDIExtension.php
+++ b/src/AutoDI/DI/AutoDIExtension.php
@@ -20,6 +20,7 @@ class AutoDIExtension extends CompilerExtension
 		'directories' => [
 			'%appDir%',
 		],
+		'ignoreDirectories' => [],
 		'defaults' => [],
 		'tempDir' => '%tempDir%',
 	];
@@ -53,6 +54,10 @@ class AutoDIExtension extends CompilerExtension
 
 		foreach ($config['directories'] as $directory) {
 			$robotLoader->addDirectory($directory);
+		}
+
+		foreach ($config['ignoreDirectories'] as $ignoredDirectory) {
+			$robotLoader->ignoreDirs = $robotLoader->ignoreDirs . ',' . $ignoredDirectory;
 		}
 
 		$robotLoader->setTempDirectory($config['tempDir']);


### PR DESCRIPTION
This code allows set ignore directories in robotloader.
Robotloader do not scan directory. 
This is necessary when you ignoring directories in robotroader in nette bootstrap. Because files are not included in cache and this extension throws exception like "class XXX can not found"